### PR TITLE
Modified the code to gracefully upgrade the fix from 2.4.2 previous version to 2.5.0 the current version

### DIFF
--- a/lib/hbs.js
+++ b/lib/hbs.js
@@ -11,7 +11,6 @@ var _ = require('lodash');
  * Regex pattern for layout directive. {{!< layout }}
  */
 var layoutPattern = /{{!<\s+([A-Za-z0-9\._\-\/]+)\s*}}/;
-var LAYOUT_ERROR = 'LAYOUT_ERROR';
 
 /**
  * Constructor
@@ -100,17 +99,12 @@ ExpressHbs.prototype.declaredLayoutFile = function(str, filename) {
 ExpressHbs.prototype.cacheLayout = function(layoutFile, useCache, cb) {
   var self = this;
 
-  if (this.restrictLayoutsTo) {
-    if (!layoutFile.startsWith(this.restrictLayoutsTo)) {
-      var err = new Error('Cannot read ' + layoutFile + ' it does not reside in ' + this.restrictLayoutsTo);
-      return cb(err, null);
-    }
+  if (path.extname(layoutFile) === '') {
+    layoutFile += this._options.extname;
   }
-
-  // assume hbs extension
-  if (path.extname(layoutFile) === '') layoutFile += this._options.extname;
-
-  // path is relative in directive, make it absolute
+  const result = this.isAllowedLayoutPath(layoutFile);
+  if (!result.ok) return cb(result.error);
+  layoutFile = result.path;
   var layoutTemplates = this.cache[layoutFile];
   if (layoutTemplates) return cb(null, layoutTemplates);
 
@@ -419,6 +413,43 @@ ExpressHbs.prototype.create = function() {
   return new ExpressHbs();
 };
 
+ExpressHbs.prototype.isAllowedLayoutPath = function(layoutPath) {
+  const resolvedPath = path.resolve(path.normalize(layoutPath));
+
+  // Case 1: Enforce restrictLayoutsTo ONLY
+  if (this.restrictLayoutsTo) {
+    const restrictPath = path.resolve(this.restrictLayoutsTo);
+    const rel = path.relative(restrictPath, resolvedPath);
+    const outside = rel.startsWith('..') || path.isAbsolute(rel);
+    if (outside) {
+      const err = new Error(`[express-hbs] Blocked malicious layout path: '${resolvedPath}'`);
+      err.code = 'LAYOUT_SECURITY';
+      return {ok: false, error: err};
+    }
+    return {ok: true, path: resolvedPath}; // ✅ passed
+  }
+
+  // Case 2: Fallback sanity check
+  const allowedDirs = []
+    .concat(this.layoutsDir || [], this.viewsDir || [], path.dirname(this._currentView || ''))
+    .filter(Boolean)
+    .map(dir => path.resolve(path.normalize(dir)))
+    .filter(dir => fs.existsSync(dir));
+
+  const isSafePath = allowedDirs.some(baseDir => {
+    const relative = path.relative(baseDir, resolvedPath);
+    return !relative.startsWith('..') && !path.isAbsolute(relative);
+  });
+
+  if (!isSafePath) {
+    const err = new Error(`[express-hbs] Blocked malicious layout path: '${resolvedPath}'`);
+    err.code = 'LAYOUT_SECURITY';
+    return {ok: false, error: err};
+  }
+
+  return {ok: true, path: resolvedPath};
+};
+
 /**
  * express 3.x, 4.x template engine compliance
  *
@@ -611,45 +642,22 @@ ExpressHbs.prototype.___express = function ___express(filename, source, options,
               // Step 1: Resolve candidate layout path
               var layoutFile = self.layoutPath(filename, path.extname(options.layout) ? options.layout : options.layout + self._options.extname);
 
-              // Step 2: Define allowed base directories
-              const allowedDirs = []
-                .concat(
-                  self.layoutsDir || [],
-                  self.viewsDir || [],
-                  path.dirname(self._currentView || '')
-                )
-                .filter(Boolean) // remove falsy entries
-                .map(dir => path.resolve(path.normalize(dir))) // normalize and make absolute
-                .filter(dir => fs.existsSync(dir)); // ensure directory exists
-              const resolvedPath = path.resolve(path.normalize(layoutFile));
-              const isSafePath = allowedDirs.some(baseDir => {
-                const relative = path.relative(baseDir, resolvedPath);
-                return (
-                  !relative.startsWith('..') &&
-                  !path.isAbsolute(relative)
-                );
-              });
+              // Step 2: Validate layout path
+              const result = self.isAllowedLayoutPath(layoutFile);
+              if (!result.ok) return cb(result.error);
+              layoutFile = result.path; // Safe resolved path
 
-              if (!isSafePath) {
-                const err = new Error(`[express-hbs] SecurityError: Blocked malicious layout path: ${resolvedPath}`);
-                err.code = LAYOUT_ERROR;
-                throw err;
-              }
-
-              // Step 4: Check existence and render layout or fallback
-              if (fs.existsSync(resolvedPath) && fs.statSync(resolvedPath).isFile()) {
-                self.cacheLayout(resolvedPath, options.cache, function(err, layoutTemplates) {
-                  if (err) return cb(err);
-                  renderIt(layoutTemplates);
-                });
-              } else {
-                // Safe but non-existent → fallback to default
+              // Step 3: If file doesn't exist, fallback to default layout
+              if (!fs.existsSync(layoutFile) || !fs.statSync(layoutFile).isFile()) {
                 return renderIt(self.defaultLayoutTemplates);
               }
+
+              // Step 4: Load the safe, existing layout
+              return self.cacheLayout(layoutFile, options.cache, function(err, layoutTemplates) {
+                if (err) return cb(err);
+                renderIt(layoutTemplates);
+              });
             } catch (e) {
-              if (e.code === LAYOUT_ERROR) {
-                return cb(e, e.message);
-              }
               return cb(e);
             }
           } else if (self.defaultLayoutTemplates) {


### PR DESCRIPTION
As part of the fix, the package throws error as following:
|  #   | Condition                       | Layout File Exists | Layout In Allowed Scope         | Action                    |
| :--: | ------------------------------- | ------------------ | ------------------------------- | ------------------------- |
| 1.a  | `restrictLayoutsTo` is **set**  |  Yes              |  Yes                           |  Render the layout       |
| 1.b  | `restrictLayoutsTo` is **set**  |  No               |  Yes                           |  Render default layout   |
| 1.c  | `restrictLayoutsTo` is **set**  |  Yes              |  No                            |  Throw Blocked Error     |
| 1.d  | `restrictLayoutsTo` is **set**  |  No               |  No                            |  Throw Blocked Error     |
| 2.a  | `restrictLayoutsTo` is not set  |  Yes              |  Yes *(layoutsDir/viewsDir)*  | Render the layout       |
| 2.b  | `restrictLayoutsTo` is not set  |  No               |  Yes                           | Render default layout   |
| 2.c  | `restrictLayoutsTo` is not set  |  Yes              |  No                            |  Throw Blocked Error     |
| 2.d  | `restrictLayoutsTo` is not set  |  No               |  No                            |  Throw Blocked Error     |
