### PR TITLE
📦 Bump npm:cross-spawn:7.0.3 to 7.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,5 +50,11 @@
   },
   "optionalDependencies": {
     "js-beautify": "^1.13.11"
+  },
+  "overrides": {
+    "cross-spawn": "7.0.6"
+  },
+  "resolutions": {
+    "cross-spawn": "7.0.6"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -777,10 +777,10 @@ cookiejar@^2.1.4:
   resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.1.4.tgz#ee669c1fea2cf42dc31585469d193fef0d65771b"
   integrity sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==
 
-cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
-  integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
+cross-spawn@7.0.6, cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
+  integrity sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==
   dependencies:
     path-key "^3.1.0"
     shebang-command "^2.0.0"


### PR DESCRIPTION
Lineaje has automatically created this pull request to resolve the following CVEs:

| CVE ID  | Severity | Description       |
|-------|-----|-----------|
| CVE-2024-21538 | High  | Versions of the package cross-spawn before 6.0.6, from 7.0.0 and before 7.0.5 are vulnerable </br>to Regular Expression Denial of Service (ReDoS) due to improper input sanitization. An </br>attacker can increase the CPU usage and crash the program by crafting a very large and </br> well crafted string. |

You can merge this PR once the tests pass and the changes are reviewed.

Thank you for reviewing the update! :rocket: