### PR TITLE
📦 Bump npm:brace-expansion:2.0.1 to 2.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,9 +52,11 @@
     "js-beautify": "^1.13.11"
   },
   "overrides": {
+    "brace-expansion": "2.0.2",
     "cross-spawn": "7.0.6"
   },
   "resolutions": {
+    "brace-expansion": "2.0.2",
     "cross-spawn": "7.0.6"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -532,18 +532,10 @@ boolean@^3.1.4:
   resolved "https://registry.yarnpkg.com/boolean/-/boolean-3.2.0.tgz#9e5294af4e98314494cbb17979fa54ca159f116b"
   integrity sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==
 
-brace-expansion@^1.1.7:
-  version "1.1.11"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
-  integrity sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==
-  dependencies:
-    balanced-match "^1.0.0"
-    concat-map "0.0.1"
-
-brace-expansion@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.1.tgz#1edc459e0f0c548486ecf9fc99f2221364b9a0ae"
-  integrity sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==
+brace-expansion@2.0.2, brace-expansion@^1.1.7, brace-expansion@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.2.tgz#54fc53237a613d854c7bd37463aad17df87214e7"
+  integrity sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==
   dependencies:
     balanced-match "^1.0.0"
 


### PR DESCRIPTION
Lineaje has automatically created this pull request to resolve the following CVEs:

| CVE ID  | Severity | Description       |
|-------|-----|-----------|
| CVE-2025-5889 | Low  | A vulnerability was found in juliangruber brace-expansion up to 1.1.11/2.0.1/3.0.0/4.0.0. </br>It has been rated as problematic. Affected by this issue is the function expand of the </br>file index.js. The manipulation leads to inefficient regular expression complexity. The </br>attack may be launched remotely. The complexity of an attack is rather high. The </br>exploitation is known to be difficult. The exploit has been disclosed to the public and </br>may be used. |

You can merge this PR once the tests pass and the changes are reviewed.

Thank you for reviewing the update! :rocket: